### PR TITLE
Add ivy and forge

### DIFF
--- a/config/doom/init.el
+++ b/config/doom/init.el
@@ -23,7 +23,7 @@
        company               ; the ultimate code completion backend
        ;; helm               ; the *other* search engine for love and life
        ;; ido                ; the other *other* search engine...
-       ;; ivy                ; a search engine for love and life
+       ivy                ; a search engine for love and life
        vertico               ; the search engine of the future
 
        :ui

--- a/config/doom/init.el
+++ b/config/doom/init.el
@@ -94,7 +94,7 @@
        gist                  ; interacting with github gists
        (lookup +dictionary +offline) ; navigate your code and its documentation
        lsp                   ; M-x vscode
-       magit                 ; a git porcelain for Emacs
+       (magit +forge)        ; a git porcelain for Emacs
        ;; make               ; run make tasks from Emacs
        ;; pass               ; password manager for nerds
        pdf                   ; pdf enhancements

--- a/env/build.sh
+++ b/env/build.sh
@@ -116,7 +116,6 @@ build_flags_set() {
         RUBY_CONFIGURE_OPTS+=" --disable-libedit"
         RUBY_GC_MALLOC_LIMIT=60000000
         RUBY_GC_HEAP_FREE_SLOTS=200000
-        WARNFLAGS="-Wno-error=implicit-function-declaration"
         shift
         ;;
       c)
@@ -136,6 +135,8 @@ build_flags_set() {
         shift
         ;;
       "")
+        WARNFLAGS=" -Wno-error=implicit-function-declaration -Wno-expansion-to-defined"
+        CFLAGS+="${WARNFLAGS}"
         build_flags_export
         [ ! $quiet_mode ] && build_flags_inspect
         return


### PR DESCRIPTION
- This patch adds the `+forge` flag to the magit module to enable communicating with source forges.
- Also adds ivy for packages that aren't yet compatible with vertico